### PR TITLE
Add command line flag to set exit country

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER David Personette <dperson@gmail.com>
 # Install tor and privoxy
 RUN export DEBIAN_FRONTEND='noninteractive' && \
     apt-get update -qq && \
+    apt-get install -y --no-install-recommends apt-utils && \
     apt-get install -qqy --no-install-recommends gnupg1 procps && \
     apt-key adv --keyserver pgp.mit.edu --recv-keys \
                 A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 && \
@@ -12,6 +13,7 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
     apt-get update -qq && \
     apt-get install -qqy --no-install-recommends tor privoxy \
                 $(apt-get -s dist-upgrade|awk '/^Inst.*ecurity/ {print $2}') &&\
+    apt-get install -y tor-geoipdb && \
     sed -i 's|^\(accept-intercepted-requests\) .*|\1 1|' /etc/privoxy/config &&\
     sed -i 's|\(127.0.0.1\|localhost\):8118|0.0.0.0:8118|' /etc/privoxy/config \
     && sed -i 's|^\(logdir\) .*|\1 /dev|' /etc/privoxy/config && \

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ tor via the socks protocol directly at `http://hostname:9050`.
                     <host:port> - destination for service request
         -t ""       Configure timezone
                     possible arg: "[timezone]" - zoneinfo timezone for container
+        -l ""       Exit location
+                    possible arg: "DE" - exit node in DE will be used
 
     The 'command' (if provided and valid) will be run instead of torproxy
 


### PR DESCRIPTION
This adds a flag `-l` that makes it possible to overwrite the country of the exit node (`-l us`. This is useful if you need an IP in a given country.