### PR TITLE
Use explicit version of Alpine to get new version of Tor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.9
 MAINTAINER David Personette <dperson@gmail.com>
 
 # Install tor and privoxy


### PR DESCRIPTION
The image on Docker Hub is rather old and the version of Tor that is packaged into it doesn't support v3 addresses. To explicitly use a new version of Alpine that has tor `0.3.4.11` in its repositories, I added the version tag.