### PR TITLE
Modify healthcheck to allow for better connection verification and startup times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ COPY torproxy.sh /usr/bin/
 
 EXPOSE 8118 9050 9051
 
-HEALTHCHECK --interval=60s --timeout=15s --start-period=90s \
-            CMD curl --socks5-hostname localhost:9050 -L 'https://api.ipify.org'
+HEALTHCHECK --interval=10s --timeout=15s \
+            CMD curl -s -x localhost:8118 'https://check.torproject.org/' | grep -q -m 1 Congratulations
 
 VOLUME ["/etc/tor", "/var/lib/tor"]
 


### PR DESCRIPTION
This new healthcheck command allows for a faster startup time of the container health status (important if you are leveraging a waiting process to verify the container is healthy before continuing). This also verifies the privoxy http proxy as well as the tor socks proxy (via privoxy), and actually checks that we are connected to tor instead of just grabbing an IP address.