### PR TITLE
fixed a likely typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ ENVIRONMENT VARIABLES
 Other environment variables beginning with `TOR_` will edit the configuration
 file accordingly:
 
- * `TOR_NewCircuitPeriod=400` will translate to `NewCircuitPeriod 10`
+ * `TOR_NewCircuitPeriod=400` will translate to `NewCircuitPeriod 400`
 
 ## Examples
 


### PR DESCRIPTION
README.md and therefore the description in Docker Hub containes the following line:

`TOR_NewCircuitPeriod=400 will translate to NewCircuitPeriod 10`

I guess that's a typo. Otherwise the run script would change the actual parameter values.