### PR TITLE
Add configuration options to run relay node and use control port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apk --no-cache --no-progress upgrade && \
     echo 'CookieAuthFileGroupReadable 1' >>/etc/tor/torrc && \
     echo 'DNSPort 5353' >>/etc/tor/torrc && \
     echo 'DataDirectory /var/lib/tor' >>/etc/tor/torrc && \
-    echo 'ExitPolicy reject *:*' >>/etc/tor/torrc && \
+    echo 'ExitPolicy reject6 *:*, reject *:*' >>/etc/tor/torrc && \
     echo 'Log notice stderr' >>/etc/tor/torrc && \
     echo 'RunAsDaemon 0' >>/etc/tor/torrc && \
     echo 'SocksPort 0.0.0.0:9050 IsolateDestAddr' >>/etc/tor/torrc && \

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ tor via the socks protocol directly at `http://hostname:9050`.
                     required args: "<port>;<host:port>"
                     <port> - port for .onion service to listen on
                     <host:port> - destination for service request
+        -t \"<ctrlport>\"  Enable and set control port
+                    (ControlPort, port 9051)
 
     The 'command' (if provided and valid) will be run instead of torproxy
 
@@ -78,6 +80,7 @@ ENVIRONMENT VARIABLES
  * `CONTACT_INFO` - Set contact info for the relay node
  * `DIR_PORT` - Enable and set port for directory mirroring (DirPort, usually 9030)
  * `OR_PORT` - Enable and set port for onion relay (ORPort, usually 9001)
+ * `CTRL_PORT` - Set control port (ControlPort, usually 9051)
 
 Other environment variables beginning with `TOR_` will edit the configuration
 file accordingly:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ tor via the socks protocol directly at `http://hostname:9050`.
                     required args: "<country>" (IE, "US" or "DE")
                     <country> - country traffic should exit in
         -n          Generate new circuits now
+        -i "<nick>" Nickname of the relay node
+        -c "<info>" Set contact info for the relay node
+        -r "<dirport>" Enable and set port for directory mirroring
+                    (DirPort, usually 9030)
+        -o "<orport>"  Enable and set port for onion relay
+                    (ORPort, usually 9001)
         -p "<password>" Configure tor HashedControlPassword for control port
         -s "<port>;<host:port>" Configure tor hidden service
                     required args: "<port>;<host:port>"
@@ -68,6 +74,10 @@ ENVIRONMENT VARIABLES
  * `TZ` - Configure the zoneinfo timezone, IE `EST5EDT`
  * `USERID` - Set the UID for the app user
  * `GROUPID` - Set the GID for the app user
+ * `NICKNAME` - Set the nickname of the relay node
+ * `CONTACT_INFO` - Set contact info for the relay node
+ * `DIR_PORT` - Enable and set port for directory mirroring (DirPort, usually 9030)
+ * `OR_PORT` - Enable and set port for onion relay (ORPort, usually 9001)
 
 Other environment variables beginning with `TOR_` will edit the configuration
 file accordingly:


### PR DESCRIPTION
This PR adds the required configuration options to run a middle (relay) node (NOT an exit node).

We also add config options for setting a custom `ControlPort`.