### PR TITLE
Improve reliability of CookieAuth use with hexdump

### DIFF
--- a/torproxy.sh
+++ b/torproxy.sh
@@ -63,9 +63,8 @@ hidden_service() { local port="$1" host="$2" file=/etc/tor/torrc
 #   N/A)
 # Return: New circuits for tor connections
 newnym() { local file=/etc/tor/run/control.authcookie
-    echo -e 'AUTHENTICATE "'"$(cat $file)"'"\nSIGNAL NEWNYM\nQUIT' |
+    echo -e 'AUTHENTICATE '"$(hexdump -e '32/1 "%02x""\n"' $file)"'\nSIGNAL NEWNYM\nQUIT' |
                 nc 127.0.0.1 9051
-    if ps -ef | egrep -v 'grep|torproxy.sh' | grep -q tor; then exit 0; fi
 }
 
 ### password: setup a hashed password


### PR DESCRIPTION
As noted in #29 CookieAuth doesn't always work.
An attempted fix was made, which resolved some issues, but not all.
Here is an alternative approach that should resolve all failures.
The source of this method is from https://stem.torproject.org/faq.html