### PR TITLE
FIX error when doing sed on non existing privoxy config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ MAINTAINER David Personette <dperson@gmail.com>
 
 # Install tor and privoxy
 RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash curl privoxy shadow tini tor tzdata&&\
+    apk --no-cache --no-progress add bash curl privoxy shadow tini tor tzdata && \
     file='/etc/privoxy/config' && \
+    touch $file && \
     sed -i 's|^\(accept-intercepted-requests\) .*|\1 1|' $file && \
     sed -i '/^listen/s|127\.0\.0\.1||' $file && \
     sed -i '/^listen.*::1/s|^|#|' $file && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -4,8 +4,9 @@ MAINTAINER David Personette <dperson@gmail.com>
 
 # Install tor and privoxy
 RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash curl privoxy shadow tini tor tzdata&&\
+    apk --no-cache --no-progress add bash curl privoxy shadow tini tor tzdata && \
     file='/etc/privoxy/config' && \
+    touch $file && \
     sed -i 's|^\(accept-intercepted-requests\) .*|\1 1|' $file && \
     sed -i '/^listen/s|127\.0\.0\.1||' $file && \
     sed -i '/^listen.*::1/s|^|#|' $file && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -4,8 +4,9 @@ MAINTAINER David Personette <dperson@gmail.com>
 
 # Install tor and privoxy
 RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash curl privoxy shadow tini tor tzdata&&\
+    apk --no-cache --no-progress add bash curl privoxy shadow tini tor tzdata && \
     file='/etc/privoxy/config' && \
+    touch $file && \
     sed -i 's|^\(accept-intercepted-requests\) .*|\1 1|' $file && \
     sed -i '/^listen/s|127\.0\.0\.1||' $file && \
     sed -i '/^listen.*::1/s|^|#|' $file && \


### PR DESCRIPTION
When doing a full build from the `Dockerfile` in the repo, I got this error because the `RUN` command tries to run `sed` on a file that does not exist.
![error](https://user-images.githubusercontent.com/8926560/115819119-7ed76c80-a3fe-11eb-9818-fb846cadacaf.png)

This commit ensures that the privoxy config file exists, before working with it.