### PR TITLE
GitHub actions CI & CD

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,66 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Publish to Docker Hub
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      -
+        name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ secrets.DOCKER_IMAGE }}
+          sep-tags: ','
+          flavor: |
+            latest=false
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=semver,pattern={{major}},prefix=v
+            type=sha
+      -
+        name: Inspect Tags
+        run: IFS=', ' read -r -a tags <<< "${{ steps.meta.outputs.tags }}"; for tag in ${tags[@]}; do echo $tag; done
+        
+      - name: Build for tags
+        run: |
+          IFS=', ' read -r -a tags <<< "${{ steps.meta.outputs.tags }}"; for tag in ${tags[@]}; do docker build -t ${tag} --platform linux/amd64,linux/386,linux/arm64,linux/ppc64le,linux/arm/v7,linux/arm/v6 .; done

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,97 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Publish to Docker Hub
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  schedule:
+    - cron: '0 10 1,15 * *' # every two weeks at 10am to update latest
+    - cron: '0 0 * * *' # Nightly build
+
+  push:
+    branches: [ master ]
+    tags:
+      - 'v*'
+  workflow_dispatch: 
+    inputs:
+      tag:
+        required: true
+        default: latest
+    
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      -
+        name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ secrets.DOCKER_IMAGE }}
+          sep-tags: ','
+          flavor: |
+            latest=false
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=semver,pattern={{major}},prefix=v
+            type=sha
+      -
+        name: Inspect Tags
+        run: IFS=', ' read -r -a tags <<< "${{ steps.meta.outputs.tags }}"; for tag in ${tags[@]}; do echo $tag; done
+        
+      - name: Build for tags
+        if: github.event.schedule != '0 10 1,15 * *'
+        run: |
+          IFS=', ' read -r -a tags <<< "${{ steps.meta.outputs.tags }}"; for tag in ${tags[@]}; do docker build -t ${tag} --push --platform linux/amd64,linux/386,linux/arm64,linux/ppc64le,linux/arm/v7,linux/arm/v6 .; done
+
+      - name: Build latest
+        if: github.event.schedule == '0 10 1,15 * *'
+        run: |
+          docker build -t ${{ secrets.DOCKER_IMAGE }}:latest --push --platform linux/amd64,linux/386,linux/arm64,linux/ppc64le,linux/arm/v7,linux/arm/v6 .
+
+      - name: Build latest
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          docker build -t ${{ secrets.DOCKER_IMAGE }}:${{ github.event.inputs.tag }} --push --platform linux/amd64,linux/386,linux/arm64,linux/ppc64le,linux/arm/v7,linux/arm/v6 .
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ MAINTAINER David Personette <dperson@gmail.com>
 
 # Install tor and privoxy
 RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash curl privoxy shadow tini tor tzdata&&\
+    apk --no-cache --no-progress add bash curl privoxy shadow tini tor tzdata && \
     file='/etc/privoxy/config' && \
+    touch $file && \
     sed -i 's|^\(accept-intercepted-requests\) .*|\1 1|' $file && \
     sed -i '/^listen/s|127\.0\.0\.1||' $file && \
     sed -i '/^listen.*::1/s|^|#|' $file && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -4,8 +4,9 @@ MAINTAINER David Personette <dperson@gmail.com>
 
 # Install tor and privoxy
 RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash curl privoxy shadow tini tor tzdata&&\
+    apk --no-cache --no-progress add bash curl privoxy shadow tini tor tzdata && \
     file='/etc/privoxy/config' && \
+    touch $file && \
     sed -i 's|^\(accept-intercepted-requests\) .*|\1 1|' $file && \
     sed -i '/^listen/s|127\.0\.0\.1||' $file && \
     sed -i '/^listen.*::1/s|^|#|' $file && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -4,8 +4,9 @@ MAINTAINER David Personette <dperson@gmail.com>
 
 # Install tor and privoxy
 RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash curl privoxy shadow tini tor tzdata&&\
+    apk --no-cache --no-progress add bash curl privoxy shadow tini tor tzdata && \
     file='/etc/privoxy/config' && \
+    touch $file && \
     sed -i 's|^\(accept-intercepted-requests\) .*|\1 1|' $file && \
     sed -i '/^listen/s|127\.0\.0\.1||' $file && \
     sed -i '/^listen.*::1/s|^|#|' $file && \


### PR DESCRIPTION
Adds support for builds using buildx on github actions. 
This removes the need for seperate Dockerfiles for each platform and makes it easier to add or remove support for additional platoforms.

Currently this has a load of kitchen sink kind of builds which can be modified as required.

- Scheduled nightly build
- scheduled latest update every 2 weeks.
- branch named builds i.e. master
- short commit ID named builds i.e. sha-4104648
- release tag, unused but available.

Requires 3 secrets to be added to the repository for docker auth and image name.

- DOCKER_USERNAME
  - Username of user to push as i.e. dperson
- DOCKER_PASSWORD 
  - Access token for the above username
- DOCKER_IMAGE 
  - configurable image name e.g. dperson/torproxy

Note: To get the container to build it also includes #64 from @pubkey 