### PR TITLE
Fix Docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER David Personette <dperson@gmail.com>
 # Install tor and privoxy
 RUN apk --no-cache --no-progress upgrade && \
     apk --no-cache --no-progress add bash curl privoxy shadow tini tor tzdata&&\
-    file='/etc/privoxy/config' && \
+    file='/etc/privoxy/config.new' && \
     sed -i 's|^\(accept-intercepted-requests\) .*|\1 1|' $file && \
     sed -i '/^listen/s|127\.0\.0\.1||' $file && \
     sed -i '/^listen.*::1/s|^|#|' $file && \


### PR DESCRIPTION
The `privoxy` package does not contain any `etc/privoxy/config` file. This file has been replaced by `etc/privoxy/config.new`.

Fix #66 #84